### PR TITLE
COMP: Use vtkMRMLLabelMapVolumeNode

### DIFF
--- a/T1_Mapping/T1_Mapping.py
+++ b/T1_Mapping/T1_Mapping.py
@@ -59,7 +59,6 @@ class T1_MappingWidget(ScriptedLoadableModuleWidget):
     self.inputSelector = slicer.qMRMLNodeComboBox()
     #self.inputSelector.nodeTypes = ( ("vtkMRMLScalarVolumeNode"), "" )
     self.inputSelector.nodeTypes = ['vtkMRMLMultiVolumeNode']
-    self.inputSelector.addAttribute( "vtkMRMLMultiVolumeNode", "LabelMap", 0 )
     self.inputSelector.selectNodeUponCreation = True
     self.inputSelector.addEnabled = False
     self.inputSelector.removeEnabled = False
@@ -75,7 +74,6 @@ class T1_MappingWidget(ScriptedLoadableModuleWidget):
     #
     self.outputSelector = slicer.qMRMLNodeComboBox()
     self.outputSelector.nodeTypes = ( ("vtkMRMLScalarVolumeNode"), "" )
-    self.outputSelector.addAttribute( "vtkMRMLScalarVolumeNode", "LabelMap", 0 )
     self.outputSelector.selectNodeUponCreation = True
     self.outputSelector.addEnabled = True
     self.outputSelector.removeEnabled = True


### PR DESCRIPTION
A new class for labelmap nodes (vtkMRMLLabelmapNode) was introduced into the Slicer core
that replaces the old method of storing segmentation in a vtkMRMLScalarVolumeNode with
a custom “labelmap” attribute set to "1".
See details here:
http://www.slicer.org/slicerWiki/index.php/Documentation/Labs/Segmentations#vtkMRMLLabelMapVolumeNode_integration

This change in the Slicer core requires modification of your extension. See the suggested change in this commit.
